### PR TITLE
Généralisation des helpers

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -42,3 +42,5 @@ rules:
   object-curly-spacing:
     - error
     - always
+  no-warning-comments:
+    - error

--- a/lib/communeHelpers.js
+++ b/lib/communeHelpers.js
@@ -1,36 +1,13 @@
-const { pick } = require('lodash');
+const { initFields, initFormat } = require('./helpers');
 
-function initCommuneFields(req, res, next) {
-  if (req.query.fields) {
-    req.fields = new Set(req.query.fields.split(','));
-  } else {
-    req.fields = new Set(['nom', 'code', 'codesPostaux', 'centre', 'surface']);
-  }
-  req.fields.add('code');
-  req.fields.add('nom');
-  next();
-}
+const initCommuneFields = initFields({
+  default: ['nom', 'code', 'codeDepartement', 'codeRegion', 'codesPostaux', 'centre', 'surface'],
+  base: ['nom', 'code'],
+});
 
-function initCommuneFormat(req, res, next) {
-  req.outputFormat = ['json', 'geojson'].includes(req.query.format) ? req.query.format : 'json';
-  if (req.outputFormat === 'geojson') {
-    req.fields.delete('contour');
-    req.fields.delete('centre');
-  }
-  next();
-}
+const initCommuneFormat = initFormat({
+  geometries: ['centre', 'contour'],
+  defaultGeometry: 'centre',
+});
 
-function formatCommune(req, commune) {
-  if (req.outputFormat === 'geojson') {
-    const geom = ['contour', 'centre'].includes(req.query.geometry) ? req.query.geometry : 'centre';
-    return {
-      type: 'Feature',
-      properties: pick(commune, Array.from(req.fields)),
-      geometry: commune[geom],
-    };
-  } else {
-    return pick(commune, Array.from(req.fields));
-  }
-}
-
-module.exports = { initCommuneFields, initCommuneFormat, formatCommune };
+module.exports = { initCommuneFields, initCommuneFormat };

--- a/lib/departementHelpers.js
+++ b/lib/departementHelpers.js
@@ -1,18 +1,8 @@
-const { pick } = require('lodash');
+const { initFields } = require('./helpers');
 
-function initDepartementFields(req, res, next) {
-  if (req.query.fields) {
-    req.fields = new Set(req.query.fields.split(','));
-  } else {
-    req.fields = new Set(['nom', 'code', 'codeRegion']);
-  }
-  req.fields.add('code');
-  req.fields.add('nom');
-  next();
-}
+const initDepartementFields = initFields({
+  default: ['nom', 'code', 'codeRegion'],
+  base: ['nom', 'code'],
+});
 
-function formatDepartement(req, departement) {
-  return pick(departement, Array.from(req.fields));
-}
-
-module.exports = { initDepartementFields, formatDepartement };
+module.exports = { initDepartementFields };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,48 @@
+const { pick } = require('lodash');
+
+function initFields(options = {}) {
+  if (!options.default || !options.base) throw new Error('Options default and base are required');
+
+  return (req, res, next) => {
+    if (req.query.fields) {
+      req.fields = new Set(req.query.fields.split(','));
+    } else {
+      req.fields = new Set(options.default);
+    }
+    options.base.forEach(field => req.fields.add(field));
+    next();
+  };
+}
+
+function initFormat(options = {}) {
+  const acceptedFormats = ['json'];
+  if (options.geometries) acceptedFormats.push('geojson');
+  if (options.geometries && !options.defaultGeometry) throw new Error('defaultGeometry is required');
+  if (options.defaultGeometry && !options.geometries.includes(options.defaultGeometry))
+    throw new Error('defaultGeometry is not in geometry list');
+
+  return (req, res, next) => {
+    req.outputFormat = acceptedFormats.includes(req.query.format) ? req.query.format : 'json';
+    if (req.outputFormat === 'geojson') {
+      req.geometries = options.geometries;
+      req.defaultGeometry = options.defaultGeometry;
+      options.geometries.forEach(geometry => req.fields.delete(geometry));
+    }
+    next();
+  };
+}
+
+function formatOne(req, target) {
+  if (req.outputFormat === 'geojson') {
+    const geom = req.geometries.includes(req.query.geometry) ? req.query.geometry : req.defaultGeometry;
+    return {
+      type: 'Feature',
+      properties: pick(target, Array.from(req.fields)),
+      geometry: target[geom],
+    };
+  } else {
+    return pick(target, Array.from(req.fields));
+  }
+}
+
+module.exports = { initFields, initFormat, formatOne };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -15,11 +15,11 @@ function initFields(options = {}) {
 }
 
 function initFormat(options = {}) {
-  const acceptedFormats = ['json'];
-  if (options.geometries) acceptedFormats.push('geojson');
   if (options.geometries && !options.defaultGeometry) throw new Error('defaultGeometry is required');
   if (options.defaultGeometry && !options.geometries.includes(options.defaultGeometry))
     throw new Error('defaultGeometry is not in geometry list');
+  const acceptedFormats = ['json'];
+  if (options.geometries) acceptedFormats.push('geojson');
 
   return (req, res, next) => {
     req.outputFormat = acceptedFormats.includes(req.query.format) ? req.query.format : 'json';

--- a/lib/regionHelpers.js
+++ b/lib/regionHelpers.js
@@ -1,18 +1,8 @@
-const { pick } = require('lodash');
+const { initFields } = require('./helpers');
 
-function initRegionFields(req, res, next) {
-  if (req.query.fields) {
-    req.fields = new Set(req.query.fields.split(','));
-  } else {
-    req.fields = new Set(['nom', 'code']);
-  }
-  req.fields.add('code');
-  req.fields.add('nom');
-  next();
-}
+const initRegionFields = initFields({
+  default: ['nom', 'code'],
+  base: ['nom', 'code'],
+});
 
-function formatRegion(req, region) {
-  return pick(region, Array.from(req.fields));
-}
-
-module.exports = { initRegionFields, formatRegion };
+module.exports = { initRegionFields };

--- a/server.js
+++ b/server.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const cors = require('cors');
 const morgan = require('morgan');
-const { initCommuneFields, initCommuneFormat, formatCommune } = require('./lib/communeHelpers');
-const { initDepartementFields, formatDepartement } = require('./lib/departementHelpers');
-const { initRegionFields, formatRegion } = require('./lib/regionHelpers');
+const { initCommuneFields, initCommuneFormat } = require('./lib/communeHelpers');
+const { initDepartementFields } = require('./lib/departementHelpers');
+const { initRegionFields } = require('./lib/regionHelpers');
+const { formatOne } = require('./lib/helpers');
 const dbCommunes = require('./lib/communes').getIndexedDb();
 const dbDepartements = require('./lib/departements').getIndexedDb();
 const dbRegions = require('./lib/regions').getIndexedDb();
@@ -43,10 +44,10 @@ app.get('/communes', initCommuneFields, initCommuneFormat, function (req, res) {
   if (req.outputFormat === 'geojson') {
     res.send({
       type: 'FeatureCollection',
-      features: result.map(commune => formatCommune(req, commune)),
+      features: result.map(commune => formatOne(req, commune)),
     });
   } else {
-    res.send(result.map(commune => formatCommune(req, commune)));
+    res.send(result.map(commune => formatOne(req, commune)));
   }
 });
 
@@ -55,7 +56,7 @@ app.get('/communes/:code', initCommuneFields, initCommuneFormat, function (req, 
   if (!commune) {
     res.sendStatus(404);
   } else {
-    res.send(formatCommune(req, commune));
+    res.send(formatOne(req, commune));
   }
 });
 
@@ -68,7 +69,7 @@ app.get('/departements', initDepartementFields, function (req, res) {
   res.send(
     dbDepartements
       .search(query)
-      .map(departement => formatDepartement(req, departement))
+      .map(departement => formatOne(req, departement))
   );
 });
 
@@ -77,7 +78,7 @@ app.get('/departements/:code', initDepartementFields, function (req, res) {
   if (!departement) {
     res.sendStatus(404);
   } else {
-    res.send(formatDepartement(req, departement));
+    res.send(formatOne(req, departement));
   }
 });
 
@@ -90,7 +91,7 @@ app.get('/regions', initRegionFields, function (req, res) {
   res.send(
     dbRegions
       .search(query)
-      .map(departement => formatRegion(req, departement))
+      .map(departement => formatOne(req, departement))
   );
 });
 
@@ -99,7 +100,7 @@ app.get('/regions/:code', initRegionFields, function (req, res) {
   if (!departement) {
     res.sendStatus(404);
   } else {
-    res.send(formatRegion(req, departement));
+    res.send(formatOne(req, departement));
   }
 });
 

--- a/test/communeHelpers.js
+++ b/test/communeHelpers.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 const expect = require('expect.js');
-const { initCommuneFields, initCommuneFormat, formatCommune } = require('../lib/communeHelpers');
+const { initCommuneFields, initCommuneFormat } = require('../lib/communeHelpers');
 
 describe('communeHelpers', function () {
 
@@ -82,44 +82,6 @@ describe('communeHelpers', function () {
         done();
       });
     });
-  });
-
-  describe('formatCommune()', function () {
-    it('should support `json` formatting', function () {
-      expect(formatCommune(
-        { outputFormat: 'json', fields: new Set() },
-        { a: 1, b: 2, c: 3, d: 4 }
-      )).to.eql({});
-    });
-
-    it('should support `geojson` formatting with `centre` as default geometry', function () {
-      expect(formatCommune(
-        { query: {}, outputFormat: 'geojson', fields: new Set() },
-        { a: 1, b: 2, c: 3, centre: 4, contour: 6 }
-      )).to.eql({ type: 'Feature', properties: {}, geometry: 4 });
-    });
-
-    it('should support `geojson` formatting with `contour` as alternative geometry', function () {
-      expect(formatCommune(
-        { query: { geometry: 'contour' }, outputFormat: 'geojson', fields: new Set() },
-        { a: 1, b: 2, c: 3, centre: 4, contour: 6 }
-      )).to.eql({ type: 'Feature', properties: {}, geometry: 6 });
-    });
-
-    it('should filter specified fields for `json`', function () {
-      expect(formatCommune(
-        { outputFormat: 'json', fields: new Set(['a', 'c']) },
-        { a: 1, b: 2, c: 3, d: 4 }
-      )).to.eql({ a: 1, c: 3 });
-    });
-
-    it('should filter specified fields for `geojson`', function () {
-      expect(formatCommune(
-        { query: {}, outputFormat: 'geojson', fields: new Set(['a', 'c']) },
-        { a: 1, b: 2, c: 3, centre: 4, contour: 6 }
-      )).to.eql({ type: 'Feature', properties: { a: 1, c: 3 }, geometry: 4 });
-    });
-
   });
 
 });

--- a/test/communeHelpers.js
+++ b/test/communeHelpers.js
@@ -18,7 +18,7 @@ describe('communeHelpers', function () {
     it('empty request should return default fields', function (done) {
       runTestCase(
         {},
-        ['nom', 'code', 'codesPostaux', 'centre', 'surface'],
+        ['nom', 'code', 'codesPostaux', 'centre', 'surface', 'codeDepartement', 'codeRegion'],
         done
       );
     });

--- a/test/departementHelpers.js
+++ b/test/departementHelpers.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 const expect = require('expect.js');
-const { initDepartementFields, formatDepartement } = require('../lib/departementHelpers');
+const { initDepartementFields } = require('../lib/departementHelpers');
 
 describe('departementHelpers', function () {
 
@@ -39,23 +39,6 @@ describe('departementHelpers', function () {
         done
       );
     });
-  });
-
-  describe('formatDepartement()', function () {
-    it('should support `json` formatting', function () {
-      expect(formatDepartement(
-        { outputFormat: 'json', fields: new Set() },
-        { a: 1, b: 2, c: 3, d: 4 }
-      )).to.eql({});
-    });
-
-    it('should filter specified fields for `json`', function () {
-      expect(formatDepartement(
-        { outputFormat: 'json', fields: new Set(['a', 'c']) },
-        { a: 1, b: 2, c: 3, d: 4 }
-      )).to.eql({ a: 1, c: 3 });
-    });
-
   });
 
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -124,7 +124,7 @@ describe('helpers', function () {
         });
 
         ['json', 'geojson'].forEach(function (format) {
-          it(format + ' should accept ' + format + ' format', function (done) {
+          it('should accept ' + format + ' format', function (done) {
             const req = { query: { format }, fields: new Set() };
             instance(req, undefined, function (err) {
               expect(err).to.be(undefined);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,228 @@
+/* eslint-env mocha */
+const expect = require('expect.js');
+const { initFields, initFormat, formatOne } = require('../lib/helpers');
+
+describe('helpers', function () {
+
+  describe('initFields()', function () {
+    describe('constructor', () => {
+      describe('no params', () => {
+        it('should throw an error', () => {
+          expect(() => initFields()).to.throwError();
+        });
+      });
+      describe('with base and default params', () => {
+        it('should success', () => {
+          expect(() => initFields({ base: ['a', 'b'], default: ['a', 'b', 'c'] })).not.to.throwError();
+        });
+      });
+    });
+
+    describe('instance', () => {
+      function runTestCase(reqParams, expectedFields, done) {
+        const req = { query: reqParams.query ? reqParams.query : {} };
+        initFields({
+          default: ['a', 'b', 'c', 'd'],
+          base: ['a', 'b'],
+        })(req, undefined, function (err) {
+          expect(err).to.be(undefined);
+          expect(req.fields).to.be.a(Set);
+          expect(Array.from(req.fields).sort()).to.eql(expectedFields.sort());
+          done();
+        });
+      }
+
+      it('empty request should return default fields', function (done) {
+        runTestCase({}, ['a', 'b', 'c', 'd'], done);
+      });
+
+      it('fields should be read from query', function (done) {
+        runTestCase(
+          { query: { fields: 'a,b,x' } },
+          ['a', 'b', 'x'],
+          done
+        );
+      });
+
+      it('base fields should always be present', function (done) {
+        runTestCase(
+          { query: { fields: 'x,y,z' } },
+          ['a', 'b', 'x', 'y', 'z'],
+          done
+        );
+      });
+    });
+  });
+
+  describe('initFormat()', function () {
+    describe('constructor', () => {
+      describe('no params', () => {
+        it('should success', () => {
+          expect(() => initFormat()).not.to.throwError();
+        });
+      });
+      describe('geometries only', () => {
+        it('should throw an error', () => {
+          expect(() => initFormat({ geometries: ['a', 'b'] })).to.throwError();
+        });
+      });
+      describe('geometries and defaultGeometry not in geometries', () => {
+        it('should throw an error', () => {
+          expect(() => initFormat({ geometries: ['a', 'b'], defaultGeometry: 'x' })).to.throwError();
+        });
+      });
+      describe('geometries and defaultGeometry in geometries', () => {
+        it('should success', () => {
+          expect(() => initFormat({ geometries: ['a', 'b'], defaultGeometry: 'a' })).not.to.throwError();
+        });
+      });
+    });
+
+    describe('instance', () => {
+      describe('entities without geometries', () => {
+        let instance;
+        beforeEach(() => instance = initFormat());
+
+        it('should set json as default format', function (done) {
+          const req = { query: {}, fields: new Set() };
+          instance(req, undefined, function (err) {
+            expect(err).to.be(undefined);
+            expect(req.outputFormat).to.be('json');
+            done();
+          });
+        });
+
+        it('should accept json format', function (done) {
+          const req = { query: { format: 'json' }, fields: new Set() };
+          instance(req, undefined, function (err) {
+            expect(err).to.be(undefined);
+            expect(req.outputFormat).to.be('json');
+            done();
+          });
+        });
+
+        it('should not accept geojson format', function (done) {
+          const req = { query: { format: 'geojson' }, fields: new Set() };
+          instance(req, undefined, function (err) {
+            expect(err).to.be(undefined);
+            expect(req.outputFormat).to.be('json');
+            done();
+          });
+        });
+      });
+      describe('entities with geometries', () => {
+        let instance;
+        beforeEach(() => instance = initFormat({ geometries: ['a', 'b'], defaultGeometry: 'a' }));
+
+        it('should set json as default format', function (done) {
+          const req = { query: {}, fields: new Set() };
+          instance(req, undefined, function (err) {
+            expect(err).to.be(undefined);
+            expect(req.outputFormat).to.be('json');
+            done();
+          });
+        });
+
+        ['json', 'geojson'].forEach(function (format) {
+          it(format + ' should accept ' + format + ' format', function (done) {
+            const req = { query: { format }, fields: new Set() };
+            instance(req, undefined, function (err) {
+              expect(err).to.be(undefined);
+              expect(req.outputFormat).to.be(format);
+              done();
+            });
+          });
+        });
+
+        it('should remove geometries from fields (geojson)', function (done) {
+          const req = { query: { format: 'geojson' }, fields: new Set(['x', 'a', 'b']) };
+          instance(req, undefined, function (err) {
+            expect(err).to.be(undefined);
+            expect(req.outputFormat).to.be('geojson');
+            expect(req.fields).to.be.a(Set);
+            expect(Array.from(req.fields).sort()).to.eql(['x'].sort());
+            done();
+          });
+        });
+
+        it('should kept geometries in fields (json)', function (done) {
+          const req = { query: { format: 'json' }, fields: new Set(['x', 'a', 'b']) };
+          instance(req, undefined, function (err) {
+            expect(err).to.be(undefined);
+            expect(req.outputFormat).to.be('json');
+            expect(req.fields).to.be.a(Set);
+            expect(Array.from(req.fields).sort()).to.eql(['x', 'a', 'b'].sort());
+            done();
+          });
+        });
+
+        it('should pass geometries and defaultGeometry in req (geojson)', done => {
+          const req = { query: { format: 'geojson' }, fields: new Set(['x', 'a', 'b']) };
+          instance(req, undefined, function (err) {
+            expect(err).to.be(undefined);
+            expect(req.geometries).to.eql(['a', 'b']);
+            expect(req.defaultGeometry).to.be('a');
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  describe('formatOne()', function () {
+    it('should support json formatting', function () {
+      expect(formatOne(
+        { outputFormat: 'json', fields: new Set() },
+        { a: 1, b: 2, c: 3, d: 4 }
+      )).to.eql({});
+    });
+
+    it('should support geojson formatting with default geometry', function () {
+      expect(formatOne(
+        {
+          query: {},
+          outputFormat: 'geojson',
+          geometries: ['x', 'y'],
+          defaultGeometry: 'x',
+          fields: new Set(),
+        },
+        { a: 1, b: 2, c: 3, x: 4, y: 6 }
+      )).to.eql({ type: 'Feature', properties: {}, geometry: 4 });
+    });
+
+    it('should support `geojson` formatting with `contour` as alternative geometry', function () {
+      expect(formatOne(
+        {
+          query: { geometry: 'y' },
+          outputFormat: 'geojson',
+          geometries: ['x', 'y'],
+          defaultGeometry: 'x',
+          fields: new Set(),
+        },
+        { a: 1, b: 2, c: 3, x: 4, y: 6 }
+      )).to.eql({ type: 'Feature', properties: {}, geometry: 6 });
+    });
+
+    it('should filter specified fields (json)', function () {
+      expect(formatOne(
+        { outputFormat: 'json', fields: new Set(['a', 'c']) },
+        { a: 1, b: 2, c: 3, d: 4 }
+      )).to.eql({ a: 1, c: 3 });
+    });
+
+    it('should filter specified fields (geojson)', function () {
+      expect(formatOne(
+        {
+          query: {},
+          outputFormat: 'geojson',
+          geometries: ['x', 'y'],
+          defaultGeometry: 'x',
+          fields: new Set(['a', 'c']),
+        },
+        { a: 1, b: 2, c: 3, x: 4, y: 6 }
+      )).to.eql({ type: 'Feature', properties: { a: 1, c: 3 }, geometry: 4 });
+    });
+
+  });
+
+});

--- a/test/regionHelpers.js
+++ b/test/regionHelpers.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 const expect = require('expect.js');
-const { initRegionFields, formatRegion } = require('../lib/regionHelpers');
+const { initRegionFields } = require('../lib/regionHelpers');
 
 describe('regionHelpers', function () {
 
@@ -39,23 +39,6 @@ describe('regionHelpers', function () {
         done
       );
     });
-  });
-
-  describe('formatRegion()', function () {
-    it('should support `json` formatting', function () {
-      expect(formatRegion(
-        { outputFormat: 'json', fields: new Set() },
-        { a: 1, b: 2, c: 3, d: 4 }
-      )).to.eql({});
-    });
-
-    it('should filter specified fields for `json`', function () {
-      expect(formatRegion(
-        { outputFormat: 'json', fields: new Set(['a', 'c']) },
-        { a: 1, b: 2, c: 3, d: 4 }
-      )).to.eql({ a: 1, c: 3 });
-    });
-
   });
 
 });


### PR DESCRIPTION
Réutilisation accrue du code.

3 helpers :
* `initFields(options)` : construction d'un middleware qui initialise la liste des champs qui seront sérialisés en sortie. Prends 2 options obligatoires : `base` qui est la liste des champs toujours sérialisés et `default` qui est la liste par défaut quand elle n'est pas fournie dans la query-string.
* `initFormat()` : permet de gérer les géométries dans le cas du GeoJSON. Prends deux options facultatives : `geometries` qui est la liste des géométries utilisables et `defaultGeometry`
* `formatOne` : sérialise les données selon les paramètres présents dans l'objet `req`