### PR TITLE
Sérialisation des entités liées

### DIFF
--- a/definition.yml
+++ b/definition.yml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
   title: API Référentiels géographiques
-  version: '0.1.0'
+  version: '1.0.0-beta'
 host: geo.api.gouv.fr
 schemes:
   - https

--- a/definition.yml
+++ b/definition.yml
@@ -15,9 +15,26 @@ parameters:
     type: array
     items:
       type: string
-      enum: ['nom','code','codesPostaux','centre','surface','contour','codeDepartement','codeRegion', 'population']
+      enum:
+        - nom
+        - code
+        - codesPostaux
+        - centre
+        - surface
+        - contour
+        - codeDepartement
+        - departement
+        - codeRegion
+        - region
+        - population
     collectionFormat: csv
-    default: ['nom','code','codesPostaux','codeDepartement','codeRegion','population']
+    default:
+      - nom
+      - code
+      - codesPostaux
+      - codeDepartement
+      - codeRegion
+      - population
   departementFieldsParam:
     name: fields
     in: query
@@ -25,9 +42,16 @@ parameters:
     type: array
     items:
       type: string
-      enum: ['nom','code','codeRegion']
+      enum:
+        - nom
+        - code
+        - codeRegion
+        - region
     collectionFormat: csv
-    default: ['nom','code','codeRegion']
+    default:
+      - nom
+      - code
+      - codeRegion
   regionFieldsParam:
     name: fields
     in: query
@@ -35,9 +59,13 @@ parameters:
     type: array
     items:
       type: string
-      enum: ['nom','code']
+      enum:
+        - nom
+        - code
     collectionFormat: csv
-    default: ['nom','code']
+    default:
+      - nom
+      - code
   formatParam:
     name: format
     in: query
@@ -207,6 +235,8 @@ paths:
           required: true
           type: string
         - $ref: '#/parameters/communeFieldsParam'
+        - $ref: '#/parameters/formatParam'
+        - $ref: '#/parameters/communeGeometryParam'
       responses:
         200:
           description: Liste des communes du département
@@ -334,6 +364,14 @@ definitions:
       codeRegion:
         type: string
         description: Code de la région associée à la commune
+      departement:
+        description: Département associé à la commune
+        schema:
+          $ref: '#/definitions/Departement'
+      region:
+        description: Région associée à la commune
+        schema:
+          $ref: '#/definitions/Region'
       population:
         type: integer
         description: Population municipale
@@ -357,10 +395,14 @@ definitions:
         type: string
         description: Nom du département
       codeRegion:
-        type: array
+        type: string
         description: Code de la région
-        items:
-          type: string
+      region:
+        $ref: '#/definitions/Region'
+        description: Région associée au département
+        type: object
+        properties:
+
   Region:
     type: object
     properties:

--- a/definition.yml
+++ b/definition.yml
@@ -365,13 +365,9 @@ definitions:
         type: string
         description: Code de la région associée à la commune
       departement:
-        description: Département associé à la commune
-        schema:
-          $ref: '#/definitions/Departement'
+        $ref: '#/definitions/Departement'
       region:
-        description: Région associée à la commune
-        schema:
-          $ref: '#/definitions/Region'
+        $ref: '#/definitions/Region'
       population:
         type: integer
         description: Population municipale
@@ -399,10 +395,6 @@ definitions:
         description: Code de la région
       region:
         $ref: '#/definitions/Region'
-        description: Région associée au département
-        type: object
-        properties:
-
   Region:
     type: object
     properties:

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -33,15 +33,27 @@ function initFormat(options = {}) {
 }
 
 function formatOne(req, target) {
+  const properties = pick(target, Array.from(req.fields));
+
+  if (target.codeDepartement && req.fields.has('departement')) {
+    const departement = req.db.departements.queryByCode(target.codeDepartement)[0];
+    properties.departement = pick(departement, 'code', 'nom');
+  }
+
+  if (target.codeRegion && req.fields.has('region')) {
+    const region = req.db.regions.queryByCode(target.codeRegion)[0];
+    properties.region = pick(region, 'code', 'nom');
+  }
+
   if (req.outputFormat === 'geojson') {
     const geom = req.geometries.includes(req.query.geometry) ? req.query.geometry : req.defaultGeometry;
     return {
       type: 'Feature',
-      properties: pick(target, Array.from(req.fields)),
+      properties,
       geometry: target[geom],
     };
   } else {
-    return pick(target, Array.from(req.fields));
+    return properties;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-communes",
-  "version": "0.1.0",
+  "version": "1.0.0-beta",
   "description": "API for French administrative units",
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -14,6 +14,16 @@ const app = express();
 app.use(cors());
 app.use(morgan('dev'));
 
+// Inject databases references
+app.use((req, res, next) => {
+  req.db = {
+    communes: dbCommunes,
+    departements: dbDepartements,
+    regions: dbRegions,
+  };
+  next();
+});
+
 /* Communes */
 app.get('/communes', initCommuneFields, initCommuneFormat, function (req, res) {
   let result;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -223,6 +223,28 @@ describe('helpers', function () {
       )).to.eql({ type: 'Feature', properties: { a: 1, c: 3 }, geometry: 4 });
     });
 
+    it('should inject departement item', function () {
+      expect(formatOne(
+        {
+          db: { departements: { queryByCode: code => [{ code, nom: 'foo' }] } },
+          query: {},
+          fields: new Set(['a', 'departement']),
+        },
+        { a: 1, b: 2, codeDepartement: 12 }
+      )).to.eql({ a: 1, departement: { code: 12, nom: 'foo' } });
+    });
+
+    it('should inject region item', function () {
+      expect(formatOne(
+        {
+          db: { regions: { queryByCode: code => [{ code, nom: 'foo' }] } },
+          query: {},
+          fields: new Set(['a', 'region']),
+        },
+        { a: 1, b: 2, codeRegion: 44 }
+      )).to.eql({ a: 1, region: { code: 44, nom: 'foo' } });
+    });
+
   });
 
 });


### PR DESCRIPTION
Lorsque les champs `departement` et/ou `region` sont demandés, ils sont obtenus par sérialisation minimale des entités correspondantes, via `formatOne`.
Fix #27 and #35