### PR TITLE
Tri de la liste des codes postaux

### DIFF
--- a/lib/integration/communes.js
+++ b/lib/integration/communes.js
@@ -273,7 +273,7 @@ function serialize(options = {}) {
         .on('error', next)
         .pipe(t((commune, enc, cb) => {
           if (commune.ancienne) return cb();
-          commune.codesPostaux = Array.from(commune.codesPostaux);
+          commune.codesPostaux = Array.from(commune.codesPostaux).sort();
           count++;
           cb(null, omit(commune, 'communesMembres', 'communeRattachement', 'ancienne'));
         }))

--- a/test/communeIntegration.js
+++ b/test/communeIntegration.js
@@ -332,7 +332,7 @@ describe('#integration communes', () => {
           ['12345', {
             code: '12345',
             nom: 'Ville-sur-Loire',
-            codesPostaux: new Set(['11111', '22222']),
+            codesPostaux: new Set(['22222', '11111']),
           }],
         ]) };
         serialize({ destPath: __dirname + '/../data/test-serialize-commune.json' })(ctx, err => {
@@ -342,7 +342,7 @@ describe('#integration communes', () => {
           expect(communes[0]).to.eql({
             code: '12345',
             nom: 'Ville-sur-Loire',
-            codesPostaux: ['11111', '22222'],
+            codesPostaux: ['11111', '22222'], // Exact order
           });
           done();
         });


### PR DESCRIPTION
Suite à une demande d'un utilisateur, la liste contenant les codes postaux d'une commune est désormais triée par ordre alphabétique.